### PR TITLE
fix(css): Correct Tailwind CSS imports

### DIFF
--- a/.llm/features/fix-tailwind-imports/PR_fix-tailwind-imports.md
+++ b/.llm/features/fix-tailwind-imports/PR_fix-tailwind-imports.md
@@ -1,0 +1,39 @@
+# PR: fix(css): Correct Tailwind CSS imports
+
+## Summary
+
+This Pull Request resolves a Vercel deployment failure by correcting outdated Tailwind CSS `@import` statements in `src/app/styles/index.css`. The granular `@import` directives (`@import "tailwindcss/base";`, etc.) have been replaced with the single, modern `@import "tailwindcss";` syntax.
+
+## Motivation
+
+The previous granular Tailwind imports were causing TypeScript compilation errors during the build process, specifically indicating that certain modules were not exported. This issue was blocking Vercel deployments. Updating to the correct import statement ensures that Tailwind CSS is properly integrated and compiled, allowing deployments to succeed.
+
+## Related Issue
+
+`.llm/issue_tailwind_css_imports.md`
+
+## Changes Made
+
+-   **`src/app/styles/index.css`**: Changed the Tailwind CSS imports from multiple granular statements to a single `@import "tailwindcss";`.
+
+## How to Test
+
+1.  Checkout this branch: `fix/tailwind-imports`
+2.  Run the build command: `npm run build` (or `npx vite build` if `npm run build` is not configured).
+3.  Ensure the build completes successfully without any errors related to Tailwind CSS imports.
+4.  Optionally, deploy to Vercel and verify the deployment succeeds.
+
+## Risks and Side Effects
+
+-   None foreseen. This is a targeted fix for a configuration issue. The visual output of the application should remain unchanged.
+
+## Checklist
+
+-   [x] Code follows project style guidelines.
+-   [ ] Tests have been added/updated to cover new functionality. (N/A for this configuration fix).
+-   [ ] Documentation has been updated (if necessary). (Issue and PR files created).
+-   [ ] All new and existing tests pass. (Verification is through successful build).
+
+## NEXT ACTION
+
+This bug fix is complete. The next action is to revert to the previous task context for feature development.

--- a/.llm/features/fix-tailwind-imports/branch.md
+++ b/.llm/features/fix-tailwind-imports/branch.md
@@ -1,0 +1,13 @@
+# Branch: fix/tailwind-imports
+
+## Feature Intent and Scope
+
+This branch addresses a critical Vercel deployment failure caused by incorrect Tailwind CSS `@import` statements in `src/app/styles/index.css`. The fix will update the imports to the correct modern syntax, ensuring successful compilation and deployment.
+
+## Related Issue
+
+`.llm/issue_tailwind_css_imports.md`
+
+## NEXT ACTION
+
+Create the `commit_fix-tailwind-imports.md` file in the `.llm/features/fix-tailwind-imports/` directory.

--- a/.llm/features/fix-tailwind-imports/commit_fix-tailwind-imports.md
+++ b/.llm/features/fix-tailwind-imports/commit_fix-tailwind-imports.md
@@ -1,0 +1,26 @@
+# Commit: fix(css): Correct Tailwind CSS imports
+
+## Summary
+
+This commit corrects the Tailwind CSS `@import` statements in `src/app/styles/index.css` to align with the modern syntax required for successful compilation and Vercel deployment.
+
+## Related Issue
+
+`.llm/issue_tailwind_css_imports.md`
+
+## Files Impacted
+
+-   `src/app/styles/index.css`: Modified to replace granular `@import` statements (`@import "tailwindcss/base";`, `@import "tailwindcss/components";`, `@import "tailwindcss/utilities";`) with a single `@import "tailwindcss";`.
+
+## Behavioral Changes
+
+-   The application will now build successfully on Vercel without Tailwind CSS import errors.
+-   The visual styling of the application remains unchanged, as the intention is to use the same Tailwind CSS features, just imported correctly.
+
+## Architectural Changes
+
+-   No significant architectural changes. This is a configuration fix.
+
+## NEXT ACTION
+
+Create the `PR_fix-tailwind-imports.md` file in the `.llm/features/fix-tailwind-imports/` directory.

--- a/.llm/issue_tailwind_css_imports.md
+++ b/.llm/issue_tailwind_css_imports.md
@@ -1,0 +1,39 @@
+# Issue: Vercel Deployment Failure - Incorrect Tailwind CSS Imports
+
+## Bug Description
+
+The Vercel deployment fails during the build process due to incorrect or deprecated `@import` statements for Tailwind CSS within `src/app/styles/index.css`. The build log indicates that specific modules like `"./base"` are not exported from the `tailwindcss` package, which points to an outdated method of importing Tailwind's layers.
+
+## Context
+
+The agent previously modified `src/app/styles/index.css` to include global styling, using `@import` statements like `@import "tailwindcss/base";`, `@import "tailwindcss/components";`, and `@import "tailwindcss/utilities";`. However, with recent Tailwind CSS versions, these granular imports are deprecated and lead to build failures. The correct modern approach is a single `@import "tailwindcss";` statement.
+
+## Error Messages (from Vercel build log)
+
+```
+[ @tailwindcss/vite:generate:build] "./base" is not exported under the condition "style" from package /vercel/path0/node_modules/tailwindcss
+file: /vercel/path0/src/app/styles/index.css
+Error: Command "npm run build" exited with 1
+```
+
+## Expected Behavior
+
+The Vercel build should complete successfully without errors related to Tailwind CSS imports. The application should correctly apply its Tailwind-based styling.
+
+## Actual Behavior
+
+The build fails with an error indicating that Tailwind CSS modules (like "base") are not exported, due to incorrect `@import` syntax in `src/app/styles/index.css`.
+
+## Steps to Reproduce
+
+1.  Attempt a Vercel deployment of the current codebase.
+2.  Observe the build logs for the Tailwind CSS import errors.
+3.  Alternatively, run `npm run build` locally and observe similar errors.
+
+## Suggested Fix (High-level)
+
+Modify `src/app/styles/index.css` to replace the granular Tailwind CSS `@import` statements with a single `@import "tailwindcss";`.
+
+## Priority
+
+High - Blocks deployment.

--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -1,6 +1,4 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@import "tailwindcss";
 
 html, body, #root {
   height: 100%;


### PR DESCRIPTION
## Summary

This Pull Request resolves a Vercel deployment failure by correcting outdated Tailwind CSS `@import` statements in `src/app/styles/index.css`. The granular `@import` directives (`@import "tailwindcss/base";`, etc.) have been replaced with the single, modern `@import "tailwindcss";` syntax.

## Motivation

The previous granular Tailwind imports were causing TypeScript compilation errors during the build process, specifically indicating that certain modules were not exported. This issue was blocking Vercel deployments. Updating to the correct import statement ensures that Tailwind CSS is properly integrated and compiled, allowing deployments to succeed.

## Related Issue

`.llm/issue_tailwind_css_imports.md`

## Changes Made

-   **`src/app/styles/index.css`**: Changed the Tailwind CSS imports from multiple granular statements to a single `@import "tailwindcss";`.

## How to Test

1.  Checkout this branch: `fix/tailwind-imports`
2.  Run the build command: `npm run build` (or `npx vite build` if `npm run build` is not configured).
3.  Ensure the build completes successfully without any errors related to Tailwind CSS imports.
4.  Optionally, deploy to Vercel and verify the deployment succeeds.

## Risks and Side Effects

-   None foreseen. This is a targeted fix for a configuration issue. The visual output of the application should remain unchanged.

## Checklist

-   [x] Code follows project style guidelines.
-   [ ] Tests have been added/updated to cover new functionality. (N/A for this configuration fix).
-   [ ] Documentation has been updated (if necessary). (Issue and PR files created).
-   [ ] All new and existing tests pass. (Verification is through successful build).

## NEXT ACTION

This bug fix is complete. The next action is to revert to the previous task context for feature development.

#12 