### PR TITLE
fix(pwa): fix manifest paths, icons, and app naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,8 @@
       sizes="180x180"
       href="/favicon/apple-touch-icon.png"
     />
-    <meta
-      name="apple-mobile-web-app-title"
-      content="https://quiz-master-nine-vert.vercel.app/"
-    />
-    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="apple-mobile-web-app-title" content="Quiz Master" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>quiz-app</title>
   </head>

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,15 +1,15 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Quiz Master",
+  "short_name": "QuizMaster",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "/favicon/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "/favicon/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
## Summary
This PR fixes multiple issues in the PWA manifest and related HTML references to ensure proper PWA install behavior, correct branding, and compliance with project rules.

### Changes included:
1. Corrected manifest URL in `index.html` to point to `/favicon/site.webmanifest` (Vite public asset path).
2. Updated icon paths in `site.webmanifest` to match actual file locations under `/favicon/`.
3. Replaced placeholder app names (`MyWebSite`, `MySite`) with meaningful names (`Quiz Master`, `QuizMaster`).
4. Corrected iOS meta tag `apple-mobile-web-app-title` to display human-readable app name.

---

## Context / Problem

The Qodo code review bot reported multiple issues related to the PWA manifest configuration:

- Manifest URL mismatch causing 404 in production.
- Incorrect icon paths preventing proper PWA installation.
- Placeholder `name` and `short_name` reducing clarity and causing branding issues.
- Wrong iOS app title (`apple-mobile-web-app-title`) displaying a URL instead of the app name.

---

## Impact

- Broken or missing PWA install metadata
- Missing icons or incorrect app appearance when installed
- Confusing or incorrect branding in browser and OS UI
- Non-compliance with project naming and correctness rules

---

## Files changed

- `index.html`
- `public/favicon/site.webmanifest`

---

## Acceptance criteria

- [x] Manifest is correctly referenced from `index.html`
- [x] Manifest icon paths match actual file locations
- [x] `name` and `short_name` use meaningful, product-specific values
- [x] `apple-mobile-web-app-title` contains the correct app title

---

## Related Issue
Fixes #16 
